### PR TITLE
fils du roc et placement reptation

### DIFF
--- a/src/packs/cof-2-base-items/capacity_Fils_du_roc_i3V8eJX0LIWb5JPd.yml
+++ b/src/packs/cof-2-base-items/capacity_Fils_du_roc_i3V8eJX0LIWb5JPd.yml
@@ -31,8 +31,9 @@ system:
       indice: 0
       label: ''
       chatFlavor: ''
-      type: buff
       img: icons/svg/d20-highlight.svg
+      type: buff
+      actionType: none
       properties:
         visible: false
         enabled: false
@@ -46,8 +47,8 @@ system:
           source: Compendium.cof-base.cof-2-base-items.Item.i3V8eJX0LIWb5JPd
           subtype: combat
           target: dr
+          value: 2 + @nivmod[10,1]
           apply: self
-          value: 2 + round(@niv/10)
           additionalInfos: ''
       resolvers: []
   cost: -1
@@ -64,11 +65,12 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.345'
+  coreVersion: '13.347'
   systemId: co
-  systemVersion: 12.331.0
+  systemVersion: 13.344.0
   createdTime: 1740761026318
-  modifiedTime: 1747376877298
+  modifiedTime: 1756182403384
   lastModifiedBy: dkGm1qUrVLQeAKiY
   exportSource: null
 _key: '!items!i3V8eJX0LIWb5JPd'
+

--- a/src/packs/cof-2-base-items/capacity_Reptation_ap9Utq8XxLfoloXI.yml
+++ b/src/packs/cof-2-base-items/capacity_Reptation_ap9Utq8XxLfoloXI.yml
@@ -1,4 +1,4 @@
-folder: KbhQw1DCiX1
+folder: KbhQw1DCiX1n3Wvx
 name: Reptation
 type: capacity
 img: icons/creatures/reptiles/lizard-mouth-glowing-red.webp
@@ -45,7 +45,7 @@ system:
   cost: -1
   rank: 2
 effects: []
-sort: 150000
+sort: 500000
 ownership:
   default: 0
   dkGm1qUrVLQeAKiY: 3
@@ -56,11 +56,12 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.346'
+  coreVersion: '13.347'
   systemId: co
   systemVersion: 13.344.0
   createdTime: 1740761026318
-  modifiedTime: 1753893565487
+  modifiedTime: 1756182376160
   lastModifiedBy: dkGm1qUrVLQeAKiY
   exportSource: null
 _key: '!items!ap9Utq8XxLfoloXI'
+

--- a/src/packs/cof-2-base-items/folders_Voie_de_la_sombre_magie_KbhQw1DCiX1n3Wvx.yml
+++ b/src/packs/cof-2-base-items/folders_Voie_de_la_sombre_magie_KbhQw1DCiX1n3Wvx.yml
@@ -17,3 +17,4 @@ _stats:
   modifiedTime: 1740828250196
   lastModifiedBy: T8QXSVbafGIxbHWi
 _key: '!folders!KbhQw1DCiX1n3Wvx'
+


### PR DESCRIPTION
Corrige la formule de fils du roc et replace reptation dans le dossier de la voie de la sombre magie du sorcier, je sais pas pourquoi il était sortie de son dossier. continuité de Fix #148 et Fix #299