### PR TITLE
amélioration du visuel des journaux

### DIFF
--- a/cof-base.css
+++ b/cof-base.css
@@ -127,16 +127,17 @@
 }
 .journal-cof-base .journal-entry-content {
   background: url("/modules/cof2-base/assets/artwork/background.webp");
+  background-color: #f6eeea;
 }
 .journal-cof-base .journal-entry-content .journal-header {
-  font-family: "Mendel Semibold", sans-serif;
+  font-family: "Matrix", sans-serif;
 }
 .journal-cof-base .journal-entry-content .journal-header input {
   border: none;
-  background-image: url("/modules/cof2-base/assets/artwork/background.webp");
+  background: url("/modules/cof2-base/assets/artwork/background.webp");
   color: #222;
 }
-.journal-cof-base .journal-entry-content .journal-entry-pages {
+.journal-cof-base .journal-entry-content {
   background-image: url("/modules/cof2-base/assets/artwork/background.webp");
 }
 .journal-cof-base .journal-entry-content .journal-entry-pages .journal-entry-page .journal-page-header h1 {


### PR DESCRIPTION
Donc pour la version 1.0.6

- avant <img src="https://puu.sh/KBGfj/e36ff5d143.jpg">

Sur Vivaldi (Chromium)
- apres-sombre <img src="https://puu.sh/KBHcv/cb8a73e31d.png">
- apres-clair <img src="https://puu.sh/KBHcp/886707f270.jpg">