### PR TITLE
Correction d'une typo sur arme

### DIFF
--- a/src/packs/cof-2-base-encounters/character_Eug_nie_Falkkenblitz__La_foudre__7xiMg1Fs6TfGAhEM.yml
+++ b/src/packs/cof-2-base-encounters/character_Eug_nie_Falkkenblitz__La_foudre__7xiMg1Fs6TfGAhEM.yml
@@ -3995,7 +3995,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Helga_Martellame_okBtDNj2D0PUkVHJ.yml
+++ b/src/packs/cof-2-base-encounters/character_Helga_Martellame_okBtDNj2D0PUkVHJ.yml
@@ -3696,7 +3696,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Ionas_Melenw__0gyfDbmKRN5X7y47.yml
+++ b/src/packs/cof-2-base-encounters/character_Ionas_Melenw__0gyfDbmKRN5X7y47.yml
@@ -1118,7 +1118,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Isildenn_d_Alista_r_ELw0a83HARZyKiGp.yml
+++ b/src/packs/cof-2-base-encounters/character_Isildenn_d_Alista_r_ELw0a83HARZyKiGp.yml
@@ -3768,7 +3768,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
+++ b/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
@@ -3787,7 +3787,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Keyrel_de_x_lys_egGnzzA0hOV3Vtzw.yml
+++ b/src/packs/cof-2-base-encounters/character_Keyrel_de_x_lys_egGnzzA0hOV3Vtzw.yml
@@ -3840,7 +3840,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
+++ b/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
@@ -3811,7 +3811,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Lhagva_fille_de_nuala_9cRMQmwX92AcjuI0.yml
+++ b/src/packs/cof-2-base-encounters/character_Lhagva_fille_de_nuala_9cRMQmwX92AcjuI0.yml
@@ -4164,7 +4164,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Mahardil_Al_Issoum_6L4Irm3wq1PT8IaT.yml
+++ b/src/packs/cof-2-base-encounters/character_Mahardil_Al_Issoum_6L4Irm3wq1PT8IaT.yml
@@ -3877,7 +3877,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Skodja_Brandebois_B9EHNKwFTf9KGTIS.yml
+++ b/src/packs/cof-2-base-encounters/character_Skodja_Brandebois_B9EHNKwFTf9KGTIS.yml
@@ -2491,7 +2491,7 @@ items:
         <p style="text-align:justify">Le joueur sélectionne sa cible puis clique
         sur l'action pour lancer le sort et dépenser les PM. Le test d'attaque à
         distance reprend les valeurs de l'arme équipée et va appliquer les DM de
-        l'amre équipée en cas de réussite. De plus, un effet de dommages
+        l'arme équipée en cas de réussite. De plus, un effet de dommages
         périodique sur 1 tour va être appliqué à la cible en cas de succès de
         l'attaque.</p> <p>Les dommages périodiques sont appliqués uniquement en
         mode Combat.</p>

--- a/src/packs/cof-2-base-encounters/character_Tybur_Prestepied_k93KnNH6EfuEpUQH.yml
+++ b/src/packs/cof-2-base-encounters/character_Tybur_Prestepied_k93KnNH6EfuEpUQH.yml
@@ -4497,7 +4497,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/character_Yellen__llee_dUgUUrXeqDTOrvgE.yml
+++ b/src/packs/cof-2-base-encounters/character_Yellen__llee_dUgUUrXeqDTOrvgE.yml
@@ -3615,7 +3615,7 @@ items:
     img: icons/weapons/daggers/dagger-twin-curved-black.webp
     _id: HqjZFypROqTwMmfG
     system:
-      description: "<p>Le poignard\_est un couteau court à lame pointue utilisé comme arme de perforation.</p><p>Il s'agit d'une amre \"légère\" ce qui permet à certains profils d'utiliser l'agilité à la place e la force pour la manier.</p><p></p><p><span class=\"hgKElc\"><strong>Arrme légère</strong></span></p>"
+      description: "<p>Le poignard\_est un couteau court à lame pointue utilisé comme arme de perforation.</p><p>Il s'agit d'une arme \"légère\" ce qui permet à certains profils d'utiliser l'agilité à la place e la force pour la manier.</p><p></p><p><span class=\"hgKElc\"><strong>Arrme légère</strong></span></p>"
       source: ''
       origin: ''
       slug: dague
@@ -3723,7 +3723,7 @@ items:
     img: icons/weapons/daggers/dagger-twin-curved-black.webp
     _id: BRrr9i1qhGcSEi4s
     system:
-      description: "<p>Un poignard\_est un couteau court à lame pointue utilisé comme arme de perforation.</p><p>Il s'agit d'une amre \"légère\" ce qui permet à certains profils d'utiliser l'agilité à la place e la force pour la manier.</p><p></p><p><span class=\"hgKElc\"><strong>Arrme légère</strong></span></p>"
+      description: "<p>Un poignard\_est un couteau court à lame pointue utilisé comme arme de perforation.</p><p>Il s'agit d'une arme \"légère\" ce qui permet à certains profils d'utiliser l'agilité à la place e la force pour la manier.</p><p></p><p><span class=\"hgKElc\"><strong>Arrme légère</strong></span></p>"
       source: ''
       origin: ''
       slug: dague

--- a/src/packs/cof-2-base-encounters/encounter_Pr_tre_Kobold_35LV9Ul76yovFUpC.yml
+++ b/src/packs/cof-2-base-encounters/encounter_Pr_tre_Kobold_35LV9Ul76yovFUpC.yml
@@ -354,7 +354,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/encounter_Shaman_orc_j175631AL1zS2xYF.yml
+++ b/src/packs/cof-2-base-encounters/encounter_Shaman_orc_j175631AL1zS2xYF.yml
@@ -320,7 +320,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-encounters/encounter_Sorcier_En4b4Q3mV1E3JylS.yml
+++ b/src/packs/cof-2-base-encounters/encounter_Sorcier_En4b4Q3mV1E3JylS.yml
@@ -361,7 +361,7 @@ items:
         <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span
         class="hgKElc">est un couteau court à lame pointue utilisé comme arme de
         perforation.</span></span></p><p><span class="BxUVEf ILfuVd"
-        lang="fr"><span class="hgKElc">Il s'agit d'une amre "légère" ce qui
+        lang="fr"><span class="hgKElc">Il s'agit d'une arme "légère" ce qui
         permet à certains profils d'utiliser l'agilité à la place e la force
         pour la manier.</span></span></p><p> </p><p><strong><span class="BxUVEf
         ILfuVd" lang="fr"><span class="hgKElc">Arrme

--- a/src/packs/cof-2-base-items/capacity_Fl_che_vivante_p7FVfkJwW2MqVKGd.yml
+++ b/src/packs/cof-2-base-items/capacity_Fl_che_vivante_p7FVfkJwW2MqVKGd.yml
@@ -15,7 +15,7 @@ system:
     <p style="text-align:justify">Le joueur sélectionne sa cible puis clique sur
     l'action pour lancer le sort et dépenser les PM. Le test d'attaque à
     distance reprend les valeurs de l'arme équipée et va appliquer les DM de
-    l'amre équipée en cas de réussite. De plus, un effet de dommages périodique
+    l'arme équipée en cas de réussite. De plus, un effet de dommages périodique
     sur 1 tour va être appliqué à la cible en cas de succès de l'attaque.</p>
     <p>Les dommages périodiques sont appliqués uniquement en mode Combat.</p>
   source: ''

--- a/src/packs/cof-2-base-items/equipment_Dague_bwFlCTHBg9Fqa0JI.yml
+++ b/src/packs/cof-2-base-items/equipment_Dague_bwFlCTHBg9Fqa0JI.yml
@@ -8,7 +8,7 @@ system:
     <p>Une dague <span class="BxUVEf ILfuVd" lang="fr"><span class="hgKElc">est
     un couteau court à lame pointue utilisé comme arme de
     perforation.</span></span></p><p><span class="BxUVEf ILfuVd" lang="fr"><span
-    class="hgKElc">Il s'agit d'une amre "légère" ce qui permet à certains
+    class="hgKElc">Il s'agit d'une arme "légère" ce qui permet à certains
     profils d'utiliser l'agilité à la place e la force pour la
     manier.</span></span></p><p> </p><p><strong><span class="BxUVEf ILfuVd"
     lang="fr"><span class="hgKElc">Arrme légère</span></span></strong></p>


### PR DESCRIPTION
Arme était mal orthographié (amre)