### PR TITLE
modification de l'image du peuple Demi-Orc

### DIFF
--- a/src/packs/cof-2-base-items/feature_Demi_orc_8F72FIIbuOar5FEq.yml
+++ b/src/packs/cof-2-base-items/feature_Demi_orc_8F72FIIbuOar5FEq.yml
@@ -1,7 +1,7 @@
 folder: pClI1itDE2etUmdy
 name: Demi-orc
 type: feature
-img: modules/cof2-base/assets/peuples/demi_orc.webp
+img: modules/cof2-base/assets/peuples/peuple_demiorc.webp
 _id: 8F72FIIbuOar5FEq
 system:
   description: >-
@@ -78,8 +78,8 @@ system:
     <h2>Caractéristiques</h2>
 
     <p>+1 FOR ou CON et ‑1 CHA ou INT</p>
-  source: ''
-  origin: ''
+  source: ""
+  origin: ""
   slug: demi-orc
   tags: []
   subtype: people
@@ -88,22 +88,22 @@ system:
       source: Compendium.cof2-base.cof-2-base-items.Item.8F72FIIbuOar5FEq
       subtype: ability
       target: for
-      value: '1'
+      value: "1"
     - type: feature
       source: Compendium.cof2-base.cof-2-base-items.Item.8F72FIIbuOar5FEq
       subtype: ability
       target: con
-      value: '1'
+      value: "1"
     - type: feature
       source: Compendium.cof2-base.cof-2-base-items.Item.8F72FIIbuOar5FEq
       subtype: ability
       target: cha
-      value: '-1'
+      value: "-1"
     - type: feature
       source: Compendium.cof2-base.cof-2-base-items.Item.8F72FIIbuOar5FEq
       subtype: ability
       target: int
-      value: '-1'
+      value: "-1"
   paths:
     - Compendium.cof2-base.cof-2-base-items.Item.iBTJTpxHCCvztvS3
   capacities: []
@@ -120,11 +120,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.348'
+  coreVersion: "13.348"
   systemId: co2
   systemVersion: 12.331.0
   createdTime: 1740760971675
   modifiedTime: 1760554475488
   lastModifiedBy: xhULmyaSSwpIRhxx
   exportSource: null
-_key: '!items!8F72FIIbuOar5FEq'
+_key: "!items!8F72FIIbuOar5FEq"


### PR DESCRIPTION
Modification du chemin d'accès vers la bonne image du dossier Asset peuples pour le Trait Demi-orc car ce n'était pas la bonne image. Possibilité en plus de supprimer l'image : modules/cof2-base/assets/peuples/demi_orc.webp
J'ai préféré ne pas le faire au cas où !!