### PR TITLE
correction lance cavalerie équipable #56

### DIFF
--- a/src/packs/cof-2-base-items/equipment_Lance_de_cavalerie_0gjyPBj5KURSdFTy.yml
+++ b/src/packs/cof-2-base-items/equipment_Lance_de_cavalerie_0gjyPBj5KURSdFTy.yml
@@ -34,7 +34,7 @@ system:
   rarity: common
   equipped: false
   properties:
-    equipable: false
+    equipable: true
     reloadable: false
     stackable: false
   usage:


### PR DESCRIPTION
L'équipement Lance de cavalerie n'était pas équipable.
https://github.com/BlackBookEditions/foundry-cof2-base/issues/56