### PR TITLE
correction capacité Dentelles et rapière activable et temporaire

### DIFF
--- a/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
+++ b/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
@@ -1877,8 +1877,7 @@ items:
         plus de son AGI), toutefois ce bonus ne peut pas dépasser le rang
         atteint dans la voie</p>
       inGame: >-
-        <p>Il s'agit d'un bonus permanent à partir du moment où la capacité est
-        apprise.</p><p></p>
+        <p>Il s'agit d'une action à activer lorsque le PJ ne porte pas d'armure.</p>
       source: ''
       origin: Livre des règles p68
       slug: dentelles-et-rapiere
@@ -1896,15 +1895,15 @@ items:
         - source: >-
             Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.9S1Hi0TOIwq0XRIV
           indice: 0
-          label: ''
+          label: 'Sans armure'
           chatFlavor: ''
           type: buff
           img: icons/svg/d20-highlight.svg
           properties:
             visible: false
             enabled: false
-            activable: false
-            temporary: false
+            activable: true
+            temporary: true
             noManaCost: false
           conditions:
             - predicate: isLearned

--- a/src/packs/cof-2-base-items/capacity_Dentelles_et_rapi_re_wLEDlG3yHUZ5NRLM.yml
+++ b/src/packs/cof-2-base-items/capacity_Dentelles_et_rapi_re_wLEDlG3yHUZ5NRLM.yml
@@ -12,8 +12,7 @@ system:
     de son AGI), toutefois ce bonus ne peut pas dépasser le rang atteint dans la
     voie</p>
   inGame: >-
-    <p>Il s'agit d'un bonus permanent à partir du moment où la capacité est
-    apprise.<p>
+    <p>Il s'agit d'une action à activer lorsque le PJ ne porte pas d'armure.</p>
   source: ''
   origin: Livre des règles p68
   slug: dentelles-et-rapiere
@@ -31,15 +30,15 @@ system:
   actions:
     - source: Compendium.cof2-base.cof-2-base-items.Item.wLEDlG3yHUZ5NRLM
       indice: 0
-      label: ''
+      label: 'Sans armure'
       chatFlavor: ''
       type: buff
       img: icons/svg/d20-highlight.svg
       properties:
         visible: false
         enabled: false
-        activable: false
-        temporary: false
+        activable: true
+        temporary: true
         noManaCost: false
       conditions:
         - predicate: isLearned


### PR DESCRIPTION
Juste rendre la capacité Activable et temporaire car si le PJ porte une armure il ne peut plus obtenir le bonus de la capacité.
La capacité est modifiée aussi sur l'un des prétirés Korléon.