### PR TITLE
correction Resolver de Nature nourriciere

### DIFF
--- a/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
+++ b/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
@@ -2166,9 +2166,8 @@ items:
         immédiatement (10 min de préparation et autant pour faire effet) et les
         dés peuvent être répartis sur plusieurs patients</p>
       inGame: >-
-        <p>L'action permet de lancer les soins totaux. En regardant les jets de
-        chaque dé, il est possible de répartir les soins entre plusieurs
-        cibles.</p>
+        <p>L'action permet de lancer un jet de DM. En regardant le résultat de
+        chaque dé, il est possible de répartir les soins entre plusieurs cibles.</p>
       source: ''
       origin: Livre des règles p72
       slug: nature-nourriciere
@@ -2199,10 +2198,12 @@ items:
           conditions:
             - predicate: isLearned
           resolvers:
-            - type: heal
+            - type: auto
               bonusDiceAdd: false
               malusDiceAdd: false
               skill:
+                difficulty: '0'
+              dmg:
                 formula: '@rangd4°'
               target:
                 type: self

--- a/src/packs/cof-2-base-items/capacity_Nature_nourrici_re_s5nFrXwFLpXYQ9Lp.yml
+++ b/src/packs/cof-2-base-items/capacity_Nature_nourrici_re_s5nFrXwFLpXYQ9Lp.yml
@@ -13,7 +13,7 @@ system:
     préparation et autant pour faire effet) et les dés peuvent être répartis sur
     plusieurs patients</p>
   inGame: >-
-    <p>L'action permet de lancer les soins totaux. En regardant les jets de
+    <p>L'action permet de lancer un jet de DM. En regardant le résultat de
     chaque dé, il est possible de répartir les soins entre plusieurs cibles.</p>
   source: ''
   origin: Livre des règles p72
@@ -45,10 +45,12 @@ system:
       conditions:
         - predicate: isLearned
       resolvers:
-        - type: heal
+        - type: auto
           bonusDiceAdd: false
           malusDiceAdd: false
           skill:
+            difficulty: '0'
+          dmg:
             formula: '@rangd4°'
           target:
             type: self


### PR DESCRIPTION
https://github.com/BlackBookEditions/foundry-cof2-base/issues/63
Correction de la capacité Nature Nourricière de base et sur un prétiré pour afficher le Jet dans le tchat et permettre de répartir le résultat de chaque dé.