### PR TITLE
corrige nature nourriciere

### DIFF
--- a/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
+++ b/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
@@ -2216,7 +2216,6 @@ items:
                 statuses: []
                 duration: '0'
                 unit: round
-              dmg: {}
           modifiers: []
           actionType: none
       cost: -1

--- a/src/packs/cof-2-base-items/capacity_Nature_nourrici_re_s5nFrXwFLpXYQ9Lp.yml
+++ b/src/packs/cof-2-base-items/capacity_Nature_nourrici_re_s5nFrXwFLpXYQ9Lp.yml
@@ -63,7 +63,6 @@ system:
             statuses: []
             duration: '0'
             unit: round
-          dmg: {}
       modifiers: []
   cost: -1
   rank: 2


### PR DESCRIPTION
corrige une ligne dans la capacité nature nourriciere qui empechait le run YMLtoLDB sur la fiche de perso de kamshaka et la capacité elle meme