### PR TITLE
modification des prétirés avec capacités Sauvegarde

### DIFF
--- a/src/packs/cof-2-base-encounters/character_Elluw_e_Chanr_a_wECdhKHcCmFzhyqk.yml
+++ b/src/packs/cof-2-base-encounters/character_Elluw_e_Chanr_a_wECdhKHcCmFzhyqk.yml
@@ -1379,12 +1379,13 @@ items:
         immédiatement et il ne peut plus être lancé avant de prendre une
         récupération rapide.</p>
       inGame: >-
-        <p>Une action va permettre de lancer le sort et consommer les PM. Cela
-        va appliquer un "effet" qui ne fait rien au sens propre du terme mais
-        permet de suivre son application pendant 1 minute en combat. Si l'effet,
-        (et l'icone de l'effet) disparaissent cela signifie que le sort a pris
-        fin. Le reste est laissé à la charge du MJ.</p> <p>L'action fonctionne
-        uniquement en mode Combat.</p>
+        <p>Une action va permettre de lancer le sort et consommer les PM. Cela va
+        appliquer un "effet" qui ne fait rien au sens propre du terme mais permet de
+        suivre son application pendant 1 minute en combat. Si l'effet, (et l'icone
+        de l'effet) disparaissent cela signifie que le sort a pris fin.
+        </p><p>L'action fonctionne uniquement en mode Combat.</p><p>La deuxième
+        action permet de réaliser le test de sauvegarde pour essayer d'attaquer le
+        prêtre.</p>
       source: ''
       origin: Livre des règles p124
       slug: sanctuaire
@@ -1436,6 +1437,42 @@ items:
               dmg: {}
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.wECdhKHcCmFzhyqk.Item.qHukdOnM3ZiuPRUs
+          indice: 1
+          label: Attaquer le prêtre
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: 10+@cha
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 2
       frequency: none
@@ -2449,8 +2486,8 @@ items:
         préjudiciable</strong>. Le MJ essaie de donner la réponse la plus utile
         possible au scénario.</p>
       inGame: >-
-        <p>L'action permet de réaliser le test de CHA difficulté 10 et de
-        dépenser les PM.</p>
+        <p>L'action permet de réaliser le test de sauvegarde de CHA difficulté 10 et
+        de dépenser les PM.</p>
       source: ''
       origin: Livre des règles p125
       slug: augure
@@ -2473,23 +2510,18 @@ items:
           type: spell
           img: icons/svg/d20-highlight.svg
           properties:
-            visible: false
-            enabled: false
             activable: true
             temporary: false
+            noChargesUsed: false
             noManaCost: false
+            visible: false
+            enabled: false
           conditions:
             - predicate: isLearned
           resolvers:
-            - type: attack
-              bonusDiceAdd: false
-              malusDiceAdd: false
-              skill:
-                formula: '@cha'
-                crit: ''
-                difficulty: '10'
-              dmg:
-                formula: '0'
+            - type: save
+              saveAbility: cha
+              saveDifficulty: '10'
               target:
                 type: self
                 number: 0
@@ -2497,10 +2529,13 @@ items:
               additionalEffect:
                 active: false
                 applyOn: success
-                successThreshold: null
                 statuses: []
                 duration: '0'
                 unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
           modifiers: []
           actionType: none
       cost: -1

--- a/src/packs/cof-2-base-encounters/character_Eug_nie_Falkkenblitz__La_foudre__7xiMg1Fs6TfGAhEM.yml
+++ b/src/packs/cof-2-base-encounters/character_Eug_nie_Falkkenblitz__La_foudre__7xiMg1Fs6TfGAhEM.yml
@@ -2509,10 +2509,10 @@ items:
       inGame: >-
         <p>Pour le moment c'est au MJ de fournir l'équipement
         @UUID[Compendium.cof2-base.cof-2-base-items.Item.BLf2dalmcwySOTBd]{Piège
-        explosif} au joueur. A terme, un système de crafting sera mis en place
-        pour créer automatiquement ces objets.</p>
-
-        <p>L'équipement est utilisable en l'état par les joueurs.</p>
+        explosif} au joueur. A terme, un système de crafting sera mis en place pour
+        créer automatiquement ces objets.</p><p>L'équipement est utilisable en
+        l'état par les joueurs.</p><p>Les actions permettent de réaliser les jets de
+        sauvegarde de la capacité.</p>
       source: ''
       origin: Livre des règles p63
       slug: piege-explosif
@@ -2526,7 +2526,77 @@ items:
         spell: false
       path: >-
         Compendium.cof2-base.cof-2-base-encounter.Actor.7xiMg1Fs6TfGAhEM.Item.oeo8v6emdIdHAPqv
-      actions: []
+      actions:
+      - source: Compendium.cof2-base.cof-2-base-encounter.Actor.7xiMg1Fs6TfGAhEM.Item.9yYST7kIipxZBpWs
+        indice: 0
+        label: 1/2 DM
+        chatFlavor: ''
+        img: icons/svg/d20-highlight.svg
+        type: buff
+        actionType: none
+        properties:
+          activable: true
+          temporary: false
+          noChargesUsed: false
+          visible: false
+          enabled: false
+          noManaCost: false
+        conditions:
+          - predicate: isLearned
+        resolvers:
+          - type: save
+            saveAbility: agi
+            saveDifficulty: '15'
+            target:
+              type: single
+              scope: all
+              number: 0
+            additionalEffect:
+              active: false
+              applyOn: success
+              statuses: []
+              duration: '0'
+              unit: round
+            bonusDiceAdd: false
+            malusDiceAdd: false
+            skill: {}
+            dmg: {}
+        modifiers: []
+      - source: Compendium.cof2-base.cof-2-base-encounter.Actor.7xiMg1Fs6TfGAhEM.Item.9yYST7kIipxZBpWs
+        indice: 1
+        label: Détecter le piège
+        chatFlavor: ''
+        img: icons/svg/d20-highlight.svg
+        type: buff
+        actionType: none
+        properties:
+          activable: true
+          temporary: false
+          noChargesUsed: true
+          visible: false
+          enabled: false
+          noManaCost: false
+        conditions:
+          - predicate: isLearned
+        resolvers:
+          - type: save
+            saveAbility: int
+            saveDifficulty: 15+@int
+            target:
+              type: single
+              scope: all
+              number: 0
+            additionalEffect:
+              active: false
+              applyOn: success
+              statuses: []
+              duration: '0'
+              unit: round
+            bonusDiceAdd: false
+            malusDiceAdd: false
+            skill: {}
+            dmg: {}
+        modifiers: []
       cost: -1
       rank: 4
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Helga_Martellame_okBtDNj2D0PUkVHJ.yml
+++ b/src/packs/cof-2-base-encounters/character_Helga_Martellame_okBtDNj2D0PUkVHJ.yml
@@ -1423,10 +1423,12 @@ items:
         DM et doivent réussir un test de FOR difficulté [10 + INT] pour ne pas
         être renversées.</p>
       inGame: >-
-        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer
-        le sort qui va automatiquement lancer les dommages. Au MJ de proposer le
-        test pour éviter le renversement.</p>  <p><em>Note : Pour utiliser la
-        "concentration" faites SHIFT+CLIC sur l'action</em></p>
+        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer le
+        sort qui va automatiquement lancer les dommages.</p><p><em>Note : Pour
+        utiliser la "concentration" faites SHIFT+CLIC sur l'action</em></p><p>La
+        deuxième action permet de réaliser le test de sauvegarde et d'appliquer le
+        statut Renversé en cas d'échec jusqu'à la fin du combat. Si la cible se
+        relève, il faut retirer l'Effet Personnalisé manuellement sur la cible.</p>
       source: ''
       origin: Livre des règles p98
       slug: frappe-des-arcanes
@@ -1477,6 +1479,46 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.okBtDNj2D0PUkVHJ.Item.Rsy7VtfRedtG7k7y
+          indice: 1
+          label: Résister au renversement
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: 10+@int
+              target:
+                type: multiple
+                number: 20
+                scope: all
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: ''
+                elementType: ''
+                statuses:
+                  - overturned
+                duration: '0'
+                unit: combat
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: none
@@ -3516,8 +3558,12 @@ items:
 
         </ul>
       inGame: >-
-        <p>Activer l'action permet de dépenser les PM. Les effets sont à gérer
-        en jeu</p>
+        <p>Activer l'action permet de dépenser les PM. Tant que l'action est
+        activée, les deux actions suivantes apparaîssent dans la liste des
+        actions.</p><p>La deuxième action permet de réaliser le test de sauvegarde
+        pour résister au gong. Si la cible rate le test, le statut Étourdi est
+        appliqué pour 1 round.</p><p>La troisième action permet de lancer les DM de
+        feu dans le chat.</p>
       source: ''
       origin: Livre des règles p101
       slug: rune-de-garde
@@ -3550,6 +3596,85 @@ items:
           modifiers: []
           resolvers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.okBtDNj2D0PUkVHJ.Item.dOBf8H9ybF4H86qS
+          indice: 1
+          label: Résister au gong
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: con
+              saveDifficulty: '15'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: ''
+                elementType: ''
+                statuses:
+                  - stun
+                duration: '1'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.okBtDNj2D0PUkVHJ.Item.dOBf8H9ybF4H86qS
+          indice: 2
+          label: DM de feu
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: auto
+              dmg:
+                formula: 3d4° + @int
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Ionas_Melenw__c1fXRDEg1AaidbMT.yml
+++ b/src/packs/cof-2-base-encounters/character_Ionas_Melenw__c1fXRDEg1AaidbMT.yml
@@ -1391,11 +1391,11 @@ items:
         moitié pour celles qui réussissent un test d’AGI difficulté [10 +
         CHA].</p>
       inGame: >-
-        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer
-        le sort qui va automatiquement lancer les dommages et dépenser les PM du
-        personnage. Au MJ de proposer le test pour réduire les dégats et les
-        appliquer.</p><p><em>Note : Pour utiliser la "concentration" faites
-        SHIFT+CLIC sur l'action</em></p>
+        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer le
+        sort qui va automatiquement lancer les dommages et dépenser les PM du
+        personnage. </p><p>La deuxième action permet de réaliser le test de
+        sauvegarde d'AGI en ciblant les acteurs touchés.</p><p><em>Note : Pour
+        utiliser la "concentration" faites SHIFT+CLIC sur l'action</em></p>
       source: ''
       origin: Livre des règles p93
       slug: foudre
@@ -1444,6 +1444,41 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.bk1hRD5aMi5znzWG
+          indice: 1
+          label: 1/2 DM
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: 10+@cha
+              target:
+                type: multiple
+                number: 10
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: none
@@ -1825,12 +1860,12 @@ items:
 
         <p> </p>
       inGame: >-
-        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        le sort qui va faire le test d'attaque magique et appliquer l'effet
-        temporaire de confusion.</p>
-
-        <p><em>Note : Le jet de dé de 6 n'est pas automatisé lui. Pour utiliser
-        la "concentration" faites SHIFT+CLIC sur l'action</em></p>
+        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer le
+        sort qui va faire le test d'attaque magique et appliquer l'effet temporaire
+        de confusion.</p><p><em>Note : Le jet de dé de 6 n'est pas automatisé lui.
+        Pour utiliser la "concentration" faites SHIFT+CLIC sur
+        l'action</em></p><p>La deuxième action permet de réaliser le test de
+        sauvegarde en ciblant l'acteur confu.</p>
       source: ''
       origin: Livre des règles p94
       slug: confusion
@@ -1885,6 +1920,41 @@ items:
                 successThreshold: null
           modifiers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.B89xQBTlq9Tknx1H
+          indice: 1
+          label: Résister au sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: vol
+              saveDifficulty: 12+@cha
+              target:
+                type: single
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: none
@@ -1929,14 +1999,14 @@ items:
         bonus à tous les tests de CHA qu’il effectue contre la victime pendant
         10 min.</p>
       inGame: >-
-        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        le sort qui va faire le test d'attaque magique et appliquer un effet
-        temporaire qui ne fait rien mais indique que la cible est sous un effet.
-        Celui-ci ne fonctionne que si le joueur est en mode combat, sinon le
-        sort se lance mais la cible n'est pas marquée.</p>
-
-        <p><em>Note : Pour utiliser la "concentration" faites SHIFT+CLIC sur
-        l'action</em></p>
+        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer le
+        sort qui va faire le test d'attaque magique et appliquer un effet temporaire
+        qui ne fait rien mais indique que la cible est sous un effet. Celui-ci ne
+        fonctionne que si le joueur est en mode combat, sinon le sort se lance mais
+        la cible n'est pas marquée.</p><p><em>Note : Pour utiliser la
+        "concentration" faites SHIFT+CLIC sur l'action</em></p><p>La deuxième action
+        permet de réaliser le test de sauvegarde pour résister au sort en ciblant
+        l'acteur.</p>
       source: ''
       origin: Livre des règles p94
       slug: amitie
@@ -1990,6 +2060,41 @@ items:
                 successThreshold: null
           modifiers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.IXTTjXr79PboZ4Ol
+          indice: 1
+          label: Résister au sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: vol
+              saveDifficulty: 10+@cha
+              target:
+                type: single
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: none
@@ -2348,12 +2453,13 @@ items:
         morts‑vivants) sont immunisées à ce sort. Les PV perdus de cette façon
         se récupèrent normalement.</p>
       inGame: >-
-        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer
-        le sort qui va automatiquement lancer les dommages. Au MJ de proposer le
-        test pour réduire les dommages et les appliquer.</p> <p>Note : Pour
-        utiliser la "concentration" faites SHIFT+CLIC sur l'action. Le nombre de
-        cibles possible est fixé sur "3" actuellmement à adapter en fonction du
-        rang du joueur.</p>
+        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer le
+        sort qui va automatiquement lancer les dommages. Au MJ de proposer le test
+        pour réduire les dommages et les appliquer.</p><p>Note : Pour utiliser la
+        "concentration" faites SHIFT+CLIC sur l'action. Le nombre de cibles possible
+        est fixé sur "3" actuellement à adapter en fonction du rang du
+        joueur.</p><p>La deuxième action permet de réaliser le test de sauvegarde
+        pour résister au sort en ciblant les acteurs.</p>
       source: ''
       origin: Livre des règles p95
       slug: sort-illusoire
@@ -2437,6 +2543,41 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.m2GGqrhfnFxlN8hi
+          indice: 2
+          label: Résister au sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: per
+              saveDifficulty: 10+@cha
+              target:
+                type: multiple
+                number: 3
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: none
@@ -2510,6 +2651,41 @@ items:
           modifiers: []
           resolvers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.c3aMhIzbvuYLB2YS
+          indice: 1
+          label: Voir au travers de l'illusion
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: 10+@cha
+              target:
+                type: single
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: none
@@ -2899,8 +3075,9 @@ items:
         test de PER difficulté [12 + CHA de l’ensorceleur] : en cas de réussite,
         elles se sentent observées</p>
       inGame: >-
-        <p>Activer l'action permet de dépenser les PM. Les effets sont à gérer
-        en jeu.</p>
+        <p>Activer la première action permet de dépenser les PM.</p><p>La deuxième
+        action permet de réaliser le test de sauvegarde pour se sentir
+        observé.</p><p> </p>
       source: ''
       origin: Livre des règles p94
       slug: clairvoyance
@@ -2931,6 +3108,41 @@ items:
           modifiers: []
           resolvers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.HP3iamRqNI5L4QWq
+          indice: 1
+          label: Se sentir observé
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: per
+              saveDifficulty: 12+@cha
+              target:
+                type: single
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: none
@@ -3211,12 +3423,13 @@ items:
         atteint par l’ensorceleur dans la voie, elle doit réussir un test de FOR
         difficulté 10 pour ne pas être renversée.</p>
       inGame: >-
-        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        le sort qui va faire le test d'attaque magique et appliquer les
-        dommages. L'effet renversé est laissé à géré par le MJ.</p>
-
-        <p><em>Note : Pour utiliser la "concentration" faites SHIFT+CLIC sur
-        l'action</em></p>
+        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer le
+        sort qui va faire le test d'attaque magique et appliquer les dommages.
+        </p><p><em>Note : Pour utiliser la "concentration" faites SHIFT+CLIC sur
+        l'action</em></p><p>La deuxième action permet de réaliser le test de
+        sauvegarde et d'appliquer le statut Renversé en cas d'échec jusqu'à la fin
+        du combat. Si la cible se relève, il faut retirer l'Effet Personnalisé
+        manuellement sur la cible.</p>
       source: ''
       origin: Livre des règles p96
       slug: choc
@@ -3267,6 +3480,44 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Actor.c1fXRDEg1AaidbMT.Item.d0NuAQA5ZFZDZf2h
+          indice: 1
+          label: NC < rang atteint
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isOwned
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: '10'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: ''
+                elementType: ''
+                unit: combat
+                statuses: []
+                duration: '0'
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 1
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
+++ b/src/packs/cof-2-base-encounters/character_Kamshaka_9fJvm0ktH9AO0zAg.yml
@@ -2168,7 +2168,8 @@ items:
       inGame: >-
         <p>L'action permet de lancer un jet de DM. En regardant le résultat de
         chaque dé, il est possible de répartir les soins entre plusieurs
-        cibles.</p>
+        cibles.</p><p>La deuxième action permet de réaslier le test pour trouver les
+        plantes médicinales.</p>
       source: ''
       origin: Livre des règles p72
       slug: nature-nourriciere
@@ -2219,6 +2220,41 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9fJvm0ktH9AO0zAg.Item.62kj9BAMBuZBbn62
+          indice: 1
+          label: Trouver les plantes
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: per
+              saveDifficulty: '10'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 2
       frequency: daily
@@ -3006,8 +3042,8 @@ items:
         caché sans risque d’être retrouvé ou rattrapé. Si le terrain est
         découvert (désert, plaine), la difficulté passe à 15.</p>
       inGame: >-
-        <p>Pas d'effets automatiques. A gérer à la main par le MJ, pour
-        l'instant</p>
+        <p>Les deux actions permettent de réaliser un test de sauvegarde en fonction
+        du milieu.</p>
       source: ''
       origin: Livre des règles p73
       slug: repli
@@ -3021,7 +3057,77 @@ items:
         spell: false
       path: >-
         Compendium.cof2-base.cof-2-base-encounter.Actor.9fJvm0ktH9AO0zAg.Item.CHAO8ZKbEFzHLJ0p
-      actions: []
+      actions:
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9fJvm0ktH9AO0zAg.Item.uepxwvQlyYUuTvw1
+          indice: 0
+          label: En milieu naturel
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: '10'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9fJvm0ktH9AO0zAg.Item.3VnFeM1u4rBdbQ2M
+          indice: 1
+          label: Milieu découvert
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: '15'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Keyrel_de_x_lys_egGnzzA0hOV3Vtzw.yml
+++ b/src/packs/cof-2-base-encounters/character_Keyrel_de_x_lys_egGnzzA0hOV3Vtzw.yml
@@ -2258,7 +2258,9 @@ items:
       inGame: >-
         <p>Le joueur sélectionne jusqu'à 3 cibles au contact puis clique sur
         l'action pour lancer le sort qui va automatiquement lancer le jet de
-        dommages et le MJ pourra leur appliquer ces dommages.</p>
+        dommages et le MJ pourra leur appliquer ces dommages.</p><p>La deuxième
+        action permet de réaliser le test de sauvegarde pour subir la moitié des DM
+        en cas de réussite.</p>
       source: ''
       origin: Livre des règles p103
       slug: arc-de-feu
@@ -2309,6 +2311,42 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.egGnzzA0hOV3Vtzw.Item.wQynJs6p0ILLsV75
+          indice: 1
+          label: 1/2 DM
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: 10+@int
+              target:
+                type: single
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 1
       frequency: none
@@ -2576,9 +2614,10 @@ items:
         DM et peuvent effectuer un test d’AGI difficulté [10 + INT] pour ne
         subir que la moitié des DM.</p>
       inGame: >-
-        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer
-        le sort qui va automatiquement lancer les dommages. Au MJ de proposer le
-        test pour réduire les dommages et les appliquer.</p>
+        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer le
+        sort qui va automatiquement lancer les dommages. </p><p>La deuxième action
+        permet de réaliser le test de sauvegarde pour subir seulement la moitié des
+        DM.</p>
       source: ''
       origin: Livre des règles p104
       slug: explosion-de-feu
@@ -2629,6 +2668,42 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.egGnzzA0hOV3Vtzw.Item.074P3Hf5i8bglCVO
+          indice: 1
+          label: 1/2 DM
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: 10+@int
+              target:
+                type: multiple
+                number: 20
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: none
@@ -2898,8 +2973,9 @@ items:
         afin d’avoir le temps de lancer le sort (réussite automatique sur
         lui‑même).</p>
       inGame: >-
-        <p>Le joueur clique sur l'action pour dépenser les PM. Les effets sont
-        gérés à la main.</p>
+        <p>Le joueur clique sur l'action pour dépenser les PM. </p><p>La deuxième
+        action permet de réaliser le test de sauvegarde en cas de chte inattendue
+        pour chacun des compagnons.</p>
       source: ''
       origin: Livre des règles p105
       slug: chute-ralentie
@@ -2932,6 +3008,42 @@ items:
           modifiers: []
           resolvers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.egGnzzA0hOV3Vtzw.Item.p7fxrQTdh1jIavW6
+          indice: 1
+          label: Si chute inattendue
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: '15'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 2
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
+++ b/src/packs/cof-2-base-encounters/character_Korl_on_Chanterune_YUEIMVRUyVGHvK5Q.yml
@@ -2110,8 +2110,9 @@ items:
         difficulté 10 pour échapper au sort). Le sort ne peut pas affecter une
         créature de niveau supérieur ou égal à celui du lanceur</p>
       inGame: >-
-        <p>Le joueur sélectionne sa cible puis clique sur l'action pour exécuter
-        un test opposé. Le traitement en cas de succès est laissé au MJ.</p>
+        <p>Le joueur sélectionne sa cible puis clique sur l'action pour exécuter un
+        test opposé. </p><p>La deuxième action permet de réaliser le test de
+        sauvegarde en cas d'actions suicidaires.</p>
       source: ''
       origin: Livre des règles p68
       slug: suggestion
@@ -2164,6 +2165,41 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.qAcobEHyYddBWoZY
+          indice: 1
+          label: Échapper au sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: '10'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: none
@@ -2501,11 +2537,10 @@ items:
         m (de long et de large). Les cibles peuvent diviser les DM par 2 si
         elles réussissent un test de CON difficulté [10 + CHA du barde].</p>
       inGame: >-
-        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer
-        le sort qui va automatiquement lancer les dommages. Au MJ de proposer le
-        test pour réduire les dégats et les appliquer.</p>
-
-        <p><em>Note : Pour utiliser la "concentration" faites SHIFT+CLIC sur
+        <p>Le joueur sélectionne ses cibles puis clique sur l'action pour lancer le
+        sort qui va automatiquement lancer les dommages. </p><p>La deuxième action
+        permet de réaliser le test de sauveagrde pour subir la moitié des
+        DM.</p><p><em>Note : Pour utiliser la "concentration" faites SHIFT+CLIC sur
         l'action</em></p>
       source: ''
       origin: Livre des règles p67
@@ -2557,6 +2592,41 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.qmx4y05OpR2IBHqM
+          indice: 1
+          label: 1/2 DM
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: con
+              saveDifficulty: 10+@cha
+              target:
+                type: multiple
+                number: 10
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []  
       cost: -1
       rank: 3
       frequency: none
@@ -3635,7 +3705,11 @@ items:
         seulement vue, 10 s’il la connaît très bien). Le sort a une durée
         maximale de CHA heures, mais il peut aussi être lancé sur un allié au
         contact et dans ce cas, il ne dure que CHA minutes.</p>
-      inGame: <p>Le joueur dépense ses PM manuellement. Pas d'effets automatiques</p>
+      inGame: >-
+        <p>La première action permet de dépenser les PM et de faire apparaître les
+        trois actions tant qu'elle est activée.</p><p>Les trois actions permettent
+        de réaliser le test de sauvegarde en fonction de la personne à imiter
+        (connue, particulière ou seulement vue).</p>
       source: ''
       origin: Livre des règles p69
       slug: deguisement
@@ -3649,7 +3723,136 @@ items:
         spell: true
       path: >-
         Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.IbEHXh8zRwJAfkmL
-      actions: []
+      actions:
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.xUiVWfDaUcQe5vN2
+          indice: 0
+          label: Activer le sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: true
+            noChargesUsed: false
+            noManaCost: false
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          modifiers: []
+          resolvers: []
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.xUiVWfDaUcQe5vN2
+          indice: 1
+          label: Personne connue
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: cha
+              saveDifficulty: '10'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.xUiVWfDaUcQe5vN2
+          indice: 2
+          label: Personne normale
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: cha
+              saveDifficulty: '15'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.YUEIMVRUyVGHvK5Q.Item.xUiVWfDaUcQe5vN2
+          indice: 3
+          label: Personne seulement vue
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: cha
+              saveDifficulty: '20'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Lhagva_fille_de_nuala_9cRMQmwX92AcjuI0.yml
+++ b/src/packs/cof-2-base-encounters/character_Lhagva_fille_de_nuala_9cRMQmwX92AcjuI0.yml
@@ -3408,8 +3408,8 @@ items:
         10. En cas de réussite, il conserve 1 PV. S’il est enragé, la réussite
         est automatique.</p>
       inGame: >-
-        <p>Pas d'effets automatiques. A gérer à la main par le MJ, pour
-        l'instant</p>
+        <p>L'action permet de réaliser le test de sauvegarde et de se soigner de 1
+        PV en cas de réussite.</p>
       source: ''
       origin: Livre des règles p82
       slug: defier-la-mort
@@ -3423,7 +3423,45 @@ items:
         spell: false
       path: >-
         Compendium.cof2-base.cof-2-base-encounter.Actor.9cRMQmwX92AcjuI0.Item.WlE2ufRR3m6cDfxH
-      actions: []
+      actions:
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9cRMQmwX92AcjuI0.Item.jrBwcsN7djxxQGFx
+          indice: 0
+          label: ''
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: con
+              saveDifficulty: '10'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: true
+                applyOn: saveSuccess
+                formulaType: heal
+                formula: '1'
+                elementType: ''
+                statuses: []
+                duration: '1'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 2
       frequency: combat
@@ -3470,8 +3508,11 @@ items:
         cesse. Le personnage peut entrer en rage une fois de plus par jour pour
         chaque capacité de rang 4 qu’il atteint dans une voie de barbare</p>
       inGame: >-
-        <p>Les effets bonus sont pris en charge via une action
-        activable/désactivable à activer en entrant en rage.</p>
+        "<p>Les effets bonus sont pris en charge via une action 
+        activable/désactivable à activer en entrant en rage.\_</p>
+        <p>Tant que la première action est activer, la deuxième action apparaît 
+        pour pouvoir effectuer le test de sauvegarde afin de sortir de la rage 
+        prématurément.</p>"
       source: ''
       origin: Livre des règles p82
       slug: rage-du-berserk
@@ -3528,6 +3569,43 @@ items:
               additionalInfos: ''
           resolvers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9cRMQmwX92AcjuI0.Item.etGY9Qc5duXAla1G
+          indice: 1
+          label: Sortir de rage
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: vol
+              saveDifficulty: '15'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: daily
@@ -3625,10 +3703,13 @@ items:
         mettre prématurément fin à la furie est égale à 20.</p>
       inGame: >-
         <p>Les effets bonus sont pris en charge via une action
-        activable/désactivable à activer en entrant en furie du Berseker.
-        ATTENTION: la rage du berseker ne doit pas être activée en même temps
-        que Furie du Berseker sinon les effets vont se cumuler. Le personnage
-        doit retirer deux utilisations de sa rage manuellement</p>
+        activable/désactivable à activer en entrant en furie du
+        Berseker.</p><p>ATTENTION : la rage du berseker ne doit pas être activée en
+        même temps que Furie du Berseker sinon les effets vont se cumuler. Le
+        personnage doit retirer deux utilisations de sa rage manuellement</p><p>Tant
+        que l'action de la furie est activée, la deuxième action apparaît. Elle
+        permet de réaliser le test de sauvegarde pour mettre fin à la furie
+        prématurément.</p>
       source: ''
       origin: Livre des règles p82
       slug: furie-du-berserk
@@ -3677,6 +3758,43 @@ items:
               additionalInfos: ''
           resolvers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.9cRMQmwX92AcjuI0.Item.zgWwFLIb1IlaDwLv
+          indice: 1
+          label: Sortir de la furie
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: vol
+              saveDifficulty: '20'
+              target:
+                type: self
+                number: 0
+                scope: all
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: daily

--- a/src/packs/cof-2-base-encounters/character_Mahardil_Al_Issoum_6L4Irm3wq1PT8IaT.yml
+++ b/src/packs/cof-2-base-encounters/character_Mahardil_Al_Issoum_6L4Irm3wq1PT8IaT.yml
@@ -1356,7 +1356,9 @@ items:
         chevalier se termine.</p>
       inGame: >-
         <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        l'attaque qui va faire le test d'attaque et appliquer les dommages.</p>
+        l'attaque qui va faire le test d'attaque et appliquer les dommages.</p><p>La
+        deuxiçme action permet de réaliser le test de sauvegarde en ciblant l'acteur
+        qui souhaite bloquer la charge. Cela applique les DM en cas de succès.</p>
       source: ''
       origin: Livre des règles p84
       slug: charge
@@ -1409,6 +1411,44 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.6L4Irm3wq1PT8IaT.Item.aJc3oqXrGNsXqsRs
+          indice: 1
+          label: Bloquer la charge
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: '20'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: 1d4°
+                elementType: ''
+                statuses: []
+                duration: '1'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: none
@@ -1794,8 +1834,9 @@ items:
         façon, la créature doit réussir un test d’INT difficulté 15 ou elle ne
         peut pas attaquer d’autre adversaire que lui à son prochain tour.</p>
       inGame: >-
-        <p>Gère le bonus aux DM via une action activable/désactivable. Le test
-        d'INT est géré manuellement pour le moment.</p>
+        <p>Gère le bonus aux DM via une action activable/désactivable. </p><p>La
+        deuxième action permet de réaliser le test de sauvegarde en ciblant le
+        leader blessé.</p>
       source: ''
       origin: Livre des règles p85
       slug: laissezlemoi
@@ -1836,6 +1877,41 @@ items:
               additionalInfos: contre un chef
           resolvers: []
           actionType: none
+        - source: Compendium.cof2-base.cof-2-base-encounter.Actor.6L4Irm3wq1PT8IaT.Item.FEIKEM9GfqxmbHzr
+          indice: 1
+          label: Si leader blessé
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: '15'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Skodja_Brandebois_B9EHNKwFTf9KGTIS.yml
+++ b/src/packs/cof-2-base-encounters/character_Skodja_Brandebois_B9EHNKwFTf9KGTIS.yml
@@ -2426,10 +2426,10 @@ items:
         difficulté [10 + PER du druide]. En cas de réussite, elle n’est plus
         affectée par le sort pour le reste du combat.</p>
       inGame: >-
-        <p>Le PJ dépense manuellement les PM. Un cercle de 10m de diamètre peut
-        être tracé sur le plan grâce à l'outil Gabarit Circulaire sur la zone
-        affectée. C'est au MJ d'immobiliser les cibles qui sont dans la zone ou
-        qu'y y rentrent</p>
+        <p>La première action permet d'activer le sort et de dépenser les PM. Tant
+        qu'elle est activer la deuxième action apparaît dans la liste des
+        actions.</p><p>La deuxième action permet de réaliser le test de sauvegarde
+        pour agir librement.</p>
       source: ''
       origin: Livre des règles p117
       slug: prison-vegetale
@@ -2443,7 +2443,64 @@ items:
         spell: true
       path: >-
         Compendium.cof2-base.cof-2-base-encounter.Actor.B9EHNKwFTf9KGTIS.Item.TMuHySDBt4PtKqbX
-      actions: []
+      actions:
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.B9EHNKwFTf9KGTIS.Item.Hl1B9WqvJcDhLBse
+          indice: 0
+          label: Activer le sort
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: true
+            noChargesUsed: false
+            noManaCost: false
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          modifiers: []
+          resolvers: []
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.B9EHNKwFTf9KGTIS.Item.Hl1B9WqvJcDhLBse
+          indice: 1
+          label: Se libérer
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+            - predicate: isLinkedActionActivated
+              object: '0'
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: 10+@per
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 2
       frequency: none

--- a/src/packs/cof-2-base-encounters/character_Tybur_Prestepied_k93KnNH6EfuEpUQH.yml
+++ b/src/packs/cof-2-base-encounters/character_Tybur_Prestepied_k93KnNH6EfuEpUQH.yml
@@ -3059,13 +3059,14 @@ items:
         Chaque personne qui creuse pour l’aider lui octroie un bonus de +2 sur
         son test (maximum +10).</p>
       inGame: >-
-        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        le sort qui va faire le test d'attaque magique et appliquer les
-        dommages. De plus un effet de dommages "périodique" sera appliqué à la
-        cible pendant la durée du sort. Il faut faire une récupération rapide
-        pour pouvoir réutiliser ce sort. Le jet pour sortir de la tombe pour la
-        cible n'est pas géré.</p> <p>L'application des DM périodiques fonctionne
-        uniquement en mode Combat.</p>
+        <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer le
+        sort qui va faire le test d'attaque magique et appliquer les dommages. De
+        plus un effet de dommages "périodique" sera appliqué à la cible pendant la
+        durée du sort. Il faut faire une récupération rapide pour pouvoir réutiliser
+        ce sort. </p><p>L'application des DM périodiques fonctionne uniquement en
+        mode Combat.</p><p>Les deux actions suivantes permettent de réaliser le test
+        de sauvegarde pour sortir de terre soit avec la FOR soit avec l'AGI en
+        ciblant les acteurs ensevellis.</p>
       source: ''
       origin: Livre des règles p110
       slug: ensevelissement
@@ -3122,6 +3123,78 @@ items:
                 successThreshold: null
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.k93KnNH6EfuEpUQH.Item.lpx4uIPrwJolfGjY
+          indice: 1
+          label: Sortir avec FOR
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: '15'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.k93KnNH6EfuEpUQH.Item.lpx4uIPrwJolfGjY
+          indice: 2
+          label: Sortir avec AGI
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            noManaCost: true
+            visible: false
+            enabled: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: agi
+              saveDifficulty: '15'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: combat

--- a/src/packs/cof-2-base-encounters/character_Wilibert_S_ret__IYVcJZhJWfnFbPD0.yml
+++ b/src/packs/cof-2-base-encounters/character_Wilibert_S_ret__IYVcJZhJWfnFbPD0.yml
@@ -2130,9 +2130,8 @@ items:
         dos un adversaire au contact. Il peut alors au choix utiliser l’attaque
         sournoise ou infliger +1d4° DM.</p>
       inGame: >-
-        <p>La capacité propose une action d'attaque utilisant l'AGI pour le jet
-        et une difficultée fixe de 15 pour indiquer le succes du test (en
-        attendant de coder le test de caractéristique plutôt qu'une attaque)</p>
+        <p>La première action permet de réaliser le test de sauvegarde.</p><p>La
+        deuxième action est à activer pour obtenir le +1d4° DM de contact.</p>
       source: ''
       origin: Livre des règles p76
       slug: acrobaties
@@ -2150,39 +2149,62 @@ items:
           indice: 0
           label: ''
           chatFlavor: ''
-          type: melee
           img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
           properties:
-            visible: false
-            enabled: false
             activable: true
             temporary: false
+            noChargesUsed: false
+            visible: false
+            enabled: false
             noManaCost: false
           conditions:
             - predicate: isLearned
           resolvers:
-            - type: attack
-              bonusDiceAdd: false
-              malusDiceAdd: false
-              skill:
-                formula: '@agi'
-                crit: ''
-                difficulty: '15'
-              dmg:
-                formula: '0'
+            - type: save
+              saveAbility: agi
+              saveDifficulty: '15'
               target:
-                type: none
+                type: self
                 number: 0
                 scope: all
               additionalEffect:
                 active: false
                 applyOn: success
-                successThreshold: null
                 statuses: []
                 duration: '0'
                 unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
           modifiers: []
+        - source: Actor.IYVcJZhJWfnFbPD0.Item.dxO5y3rUiNicpGaM
+          indice: 1
+          label: DM supplémentaires
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: buff
           actionType: none
+          properties:
+            activable: true
+            temporary: true
+            noChargesUsed: false
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          modifiers:
+            - type: capacity
+              source: Actor.IYVcJZhJWfnFbPD0.Item.dxO5y3rUiNicpGaM
+              subtype: combat
+              target: damMelee
+              value: 1d4°
+              apply: self
+              additionalInfos: ''
+          resolvers: []
       cost: -1
       rank: 3
       frequency: none
@@ -2639,7 +2661,8 @@ items:
         seconde fois (sauf si son INT est de ‑4).</p>
       inGame: >-
         <p>Seul le bonus de 1d4° PV est pris en charge en cliquant sur le bouton
-        d'action de cette capacité.</p>
+        d'action de cette capacité.</p><p>La deuxième action permet de cibler un
+        acteur pour qu'il réalise le test de savegarde.</p>
       source: ''
       origin: Livre des règles p76
       slug: feindre-la-mort
@@ -2687,6 +2710,41 @@ items:
               dmg: {}
           modifiers: []
           actionType: none
+        - source: Actor.IYVcJZhJWfnFbPD0.Item.0JUkid6qiE2igXEQ
+          indice: 1
+          label: Révéler la supercherie
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: int
+              saveDifficulty: '20'
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: false
+                applyOn: success
+                statuses: []
+                duration: '0'
+                unit: round
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 3
       frequency: combat
@@ -2827,12 +2885,14 @@ items:
         l’inconscience pour 2d6 min (4d6 min pour 2 doses, etc.).</p>
       inGame: >-
         <p>Le joueur sélectionne sa cible puis clique sur l'action pour lancer
-        l'attaque qui va faire le test d'attaque de l'arme équipée, ainsi que
-        ses dommages et si l'attaque réussie appliquera le statut "empoisonné"
-        pour 1 round ainsi que 2d4° DM de type "Poison". Ne fonctionne qu'en
-        mode combat</p><p><em>Note : On aurait aussi pu mettre un bonus
-        activable/desactivable augmentant les DM. A voir sur l'usage ce qui est
-        le mieux.</em></p>
+        l'attaque qui va faire le test d'attaque de l'arme équipée, ainsi que ses
+        dommages et si l'attaque réussie appliquera le statut "empoisonné" pour 1
+        round ainsi que 2d4° DM de type "Poison". Ne fonctionne qu'en mode
+        combat</p><p><em>Note : On aurait aussi pu mettre un bonus
+        activable/desactivable augmentant les DM. A voir sur l'usage ce qui est le
+        mieux.</em></p><p>La deuxième action permet de réaliser le test de
+        sauvegarde et d'appliquer le statut Affaibli pour le reste du combat si la
+        cible le rate.</p>
       source: ''
       origin: Livre des règles p76
       slug: maitre-du-poison
@@ -2887,6 +2947,45 @@ items:
                 successThreshold: null
           modifiers: []
           actionType: none
+        - source: Actor.IYVcJZhJWfnFbPD0.Item.nDVwGd2NwqZfDEay
+          indice: 1
+          label: Test de sauvegarde
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: con
+              saveDifficulty: 10+@int
+              target:
+                type: single
+                scope: all
+                number: 0
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: ''
+                elementType: ''
+                statuses:
+                  - weakened
+                unit: combat
+                duration: '0'
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 5
       frequency: daily

--- a/src/packs/cof-2-base-encounters/character_Yellen__llee_dUgUUrXeqDTOrvgE.yml
+++ b/src/packs/cof-2-base-encounters/character_Yellen__llee_dUgUUrXeqDTOrvgE.yml
@@ -1426,8 +1426,10 @@ items:
         DM à tous les adversaires au contact et oblige ceux‑ci à réussir un test
         de FOR difficulté 10 pour ne pas être renversés.</p>
       inGame: >-
-        <p>L'action permet de réaliser l'attaque automatique sur les cibles.</p>
-        <p>Il faudra une récupération Rapide pour utiliser à nouveau cette
+        <p>L'action permet de réaliser l'attaque automatique sur les
+        cibles.</p><p>La deuxième action permet de réaliser le test de sauvegarde et
+        d'appliquer le statut Renversé sur les cibles qui ont raté leur
+        test.</p><p>Il faudra une récupération Rapide pour utiliser à nouveau cette
         capacités.</p>
       source: ''
       origin: Livre des règles p119
@@ -1479,6 +1481,46 @@ items:
                 unit: round
           modifiers: []
           actionType: none
+        - source: >-
+            Compendium.cof2-base.cof-2-base-encounter.Actor.dUgUUrXeqDTOrvgE.Item.2CSNt768vLVoQkqM
+          indice: 1
+          label: Résister au renversement
+          chatFlavor: ''
+          img: icons/svg/d20-highlight.svg
+          type: spell
+          actionType: none
+          properties:
+            activable: true
+            temporary: false
+            noChargesUsed: true
+            visible: false
+            enabled: false
+            noManaCost: false
+          conditions:
+            - predicate: isLearned
+          resolvers:
+            - type: save
+              saveAbility: for
+              saveDifficulty: '10'
+              target:
+                type: multiple
+                number: 8
+                scope: all
+              additionalEffect:
+                active: true
+                applyOn: saveFailure
+                formulaType: damage
+                formula: ''
+                elementType: ''
+                statuses:
+                  - overturned
+                duration: '0'
+                unit: combat
+              bonusDiceAdd: false
+              malusDiceAdd: false
+              skill: {}
+              dmg: {}
+          modifiers: []
       cost: -1
       rank: 4
       frequency: combat

--- a/src/packs/cof-2-base-items/capacity_Confusion_E9GxCOhtOf2JTcVk.yml
+++ b/src/packs/cof-2-base-items/capacity_Confusion_E9GxCOhtOf2JTcVk.yml
@@ -71,7 +71,8 @@ system:
             formulaType: damage
             formula: ''
             elementType: ''
-            statuses: []
+            statuses:
+              - confused
             duration: '@cha'
             unit: round
       modifiers: []


### PR DESCRIPTION
Modification de tous les prétirés avec la nouvelle version des capacités intégrant les Resolver de type Sauvegarde.
Ajout du statut "confus" sur la capacité Confusion car il a du se retirer automatiquement à cause du bug corrigé depuis.