### PR TITLE
corrige proteger un allie en mettant un jet de competence plutot que …

### DIFF
--- a/src/packs/cof-2-base-items/capacity_Prot_ger_un_alli__urKud713uiGWfNeX.yml
+++ b/src/packs/cof-2-base-items/capacity_Prot_ger_un_alli__urKud713uiGWfNeX.yml
@@ -34,36 +34,40 @@ system:
       indice: 0
       label: ''
       chatFlavor: ''
-      type: buff
       img: icons/svg/d20-highlight.svg
+      type: buff
+      actionType: none
       properties:
-        visible: false
-        enabled: false
         activable: false
         temporary: false
+        noChargesUsed: false
+        visible: false
+        enabled: false
         noManaCost: false
       conditions:
         - predicate: isLearned
       modifiers:
         - type: capacity
           source: Compendium.cof2-base.cof-2-base-items.Item.urKud713uiGWfNeX
-          subtype: ability
+          subtype: skill
           target: per
-          apply: self
           value: 2 + @rang
+          apply: self
           additionalInfos: éviter d'être surpris
       resolvers: []
     - source: Compendium.cof2-base.cof-2-base-items.Item.urKud713uiGWfNeX
       indice: 1
       label: ''
       chatFlavor: ''
-      type: buff
       img: icons/svg/d20-highlight.svg
+      type: buff
+      actionType: none
       properties:
-        visible: false
-        enabled: false
         activable: true
         temporary: false
+        noChargesUsed: false
+        visible: false
+        enabled: false
         noManaCost: false
       conditions:
         - predicate: isLearned
@@ -72,13 +76,11 @@ system:
           source: Compendium.cof2-base.cof-2-base-items.Item.urKud713uiGWfNeX
           subtype: combat
           target: def
-          apply: others
           value: '2'
+          apply: others
           additionalInfos: si non surpris
       resolvers:
         - type: buffDebuff
-          bonusDiceAdd: false
-          malusDiceAdd: false
           target:
             type: single
             scope: all
@@ -92,9 +94,12 @@ system:
             statuses: []
             duration: '1'
             unit: round
-            successThreshold: null
+          bonusDiceAdd: false
+          malusDiceAdd: false
           skill: {}
           dmg: {}
+          halfDmgOnSave: true
+          hasAttackSuccessThreshold: false
   cost: -1
   rank: 1
 effects: []
@@ -109,11 +114,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.345'
+  coreVersion: '14.361'
   systemId: co2
-  systemVersion: 12.331.0
+  systemVersion: '#{VERSION}#'
   createdTime: 1740761026318
-  modifiedTime: 1747891163024
+  modifiedTime: 1778440156014
   lastModifiedBy: dkGm1qUrVLQeAKiY
   exportSource: null
 _key: '!items!urKud713uiGWfNeX'


### PR DESCRIPTION
…caracteristique

Corrige la capacité "protéger un allié" qui augmentait la caractéristique PER au lieu de donne rang +2 en jet de compétence pour éviter d'etre surpris