### PR TITLE
Fix movement immunity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.1.4
+
+- Mise à jour du guide du système par rapport au groupement par choix des modificateurs
+- Mise à jour des Peuples par rapport au groupement par choix des modificateurs
+- Correction de l'équipement Piège explosif
+- Mise àjour des rencontres par rapport à la résolution de type Sauvegarde : Araignée géante, chimère draconique, CryoHydre, Dragon des forêts, Drake givré, Skrambler
+- Mise à jour des prétirés par rapport à la résolution de type Sauvegarde : Ionas, Keyrel, Chanterune
+- Mise à jour des capacités et des prétirés: modification du nombre de cibles. Correction de Sommeil, Sort illusoire et Ecuyer. 49 capacités avec 0 pour indiquer illimité et non un chiffre élevé.
+
 # 2.1.3
 
 ## Corrections

--- a/src/packs/cof-2-base-items/capacity_Course_des_airs_7sW3kPe2dvuytLjq.yml
+++ b/src/packs/cof-2-base-items/capacity_Course_des_airs_7sW3kPe2dvuytLjq.yml
@@ -48,7 +48,7 @@ system:
         - type: capacity
           source: Compendium.cof2-base.cof-2-base-items.Item.7sW3kPe2dvuytLjq
           subtype: state
-          target: movemenAlterationImmunity
+          target: movementAlterationImmunity
           value: '0'
           apply: self
           additionalInfos: ''

--- a/src/packs/cof-2-base-items/capacity_Libert__d_action_rBSuZpT9FPPHWivR.yml
+++ b/src/packs/cof-2-base-items/capacity_Libert__d_action_rBSuZpT9FPPHWivR.yml
@@ -53,7 +53,7 @@ system:
         - type: capacity
           source: Compendium.cof2-base.cof-2-base-items.Item.rBSuZpT9FPPHWivR
           subtype: state
-          target: movemenAlterationImmunity
+          target: movementAlterationImmunity
           value: '0'
       resolvers: []
   cost: -1


### PR DESCRIPTION
Lorsque j'ai corrigé une faute d'orthographe de movemenAlterationImmunity vers movementAlterationImmunity celà à impacté 2 capacités et un prétiré : 

- Liberté de mouvement du saltimbanque et course des airs ainsique le prétiré Chantelune qui a le profil de barde
J'ai dû corriger du coup ces elements